### PR TITLE
Use symbols for source

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,7 +81,7 @@ parameters {
           description: 'List data from JSON source.', 
           defaultValue: '', 
           query: '$[*].name', 
-          source: [$class: 'ConfigFileSource', configId: 'my-id', folderPath: 'FolderA', folderScoped: true]
+          source: configFileSource(configId: 'my-id', folderPath: 'FolderA', folderScoped: true)
   )
 }
 ```
@@ -100,7 +100,7 @@ parameters {
           description: 'List data from JSON source.', 
           defaultValue: 'Alpha', 
           query: '$[*].name', 
-          source: [$class: 'ConfigFileSource', configId: 'my-id', folderPath: '', folderScoped: false]
+          source: configFileSource(configId: 'my-id', folderPath: '', folderScoped: false)
   )
 }
 ```
@@ -119,7 +119,7 @@ parameters {
           description: 'List data from JSON source.', 
           defaultValue: 'Beta', 
           query: '$[*].name',
-          source: [$class: 'RemoteSource', credentialsId: 'my-id', url: 'https://dummyjson.com/api/data']
+          source: remoteSource(credentialsId: 'my-id', url: 'https://dummyjson.com/api/data')
   )
 }
 ```

--- a/pom.xml
+++ b/pom.xml
@@ -89,6 +89,11 @@
       <artifactId>workflow-job</artifactId>
       <scope>test</scope>
     </dependency>
+    <dependency>
+      <groupId>org.jenkinsci.plugins</groupId>
+      <artifactId>pipeline-model-definition</artifactId>
+      <scope>test</scope>
+    </dependency>
   </dependencies>
 
   <repositories>

--- a/src/main/java/com/github/cyanbaz/jenkins/plugins/jsonparameter/ConfigFileSource.java
+++ b/src/main/java/com/github/cyanbaz/jenkins/plugins/jsonparameter/ConfigFileSource.java
@@ -13,6 +13,7 @@ import java.util.HashSet;
 import java.util.Optional;
 import java.util.Set;
 import jenkins.model.Jenkins;
+import org.jenkinsci.Symbol;
 import org.jenkinsci.lib.configprovider.model.Config;
 import org.jenkinsci.plugins.configfiles.GlobalConfigFiles;
 import org.jenkinsci.plugins.configfiles.folder.FolderConfigFileProperty;
@@ -147,6 +148,7 @@ public class ConfigFileSource extends JsonSource {
      * Descriptor for {@link ConfigFileSource}, shown as an option in the dropdown selector.
      */
     @Extension
+    @Symbol({"configFileSource"})
     public static class DescriptorImpl extends Descriptor<JsonSource> {
 
         /**

--- a/src/main/java/com/github/cyanbaz/jenkins/plugins/jsonparameter/RemoteSource.java
+++ b/src/main/java/com/github/cyanbaz/jenkins/plugins/jsonparameter/RemoteSource.java
@@ -28,6 +28,7 @@ import java.net.http.HttpRequest;
 import java.net.http.HttpResponse;
 import java.nio.charset.StandardCharsets;
 import java.util.Base64;
+import org.jenkinsci.Symbol;
 import org.jenkinsci.plugins.plaincredentials.StringCredentials;
 import org.kohsuke.stapler.AncestorInPath;
 import org.kohsuke.stapler.DataBoundConstructor;
@@ -170,6 +171,7 @@ public class RemoteSource extends JsonSource {
      * Descriptor for the {@link RemoteSource}, used to display this option in the Jenkins UI dropdown.
      */
     @Extension
+    @Symbol({"remoteSource"})
     public static class DescriptorImpl extends Descriptor<JsonSource> {
 
         /**


### PR DESCRIPTION
Use symbols for source
Updated examples

### Testing done

mvn clean install and tested with following pipeline (hpi run)

```groovy
pipeline {
    parameters {
        jsonParam(
            name: 'json_param',
            description: 'List data from JSON source2.',
            defaultValue: '',
            query: '$[*].foo',
            source: remoteSource(url: 'https://dummyjson.com/c/f0c9-7c0a-4baa-bfaf', credentialsId: '')
        )
    }
    agent {
        label('built-in')
    }
    stages {
        stage('JSON parameter') {
            steps {
                println(params.json_param)
            }
        }
    }
}

```

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests that demonstrate the feature works or the issue is fixed

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
