### PR TITLE
chore(build): upgrade Jenkins baseline to 2.541

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -6,6 +6,6 @@ buildPlugin(
   forkCount: '1C', // run this number of tests in parallel for faster feedback.  If the number terminates with a 'C', the value will be multiplied by the number of available CPU cores
   useContainerAgent: true, // Set to `false` if you need to use Docker for containerized tests
   configurations: [
-    [platform: 'linux', jdk: 21],
-    [platform: 'windows', jdk: 17],
+    [platform: 'linux', jdk: 25],
+    [platform: 'windows', jdk: 21],
 ])

--- a/pom.xml
+++ b/pom.xml
@@ -37,7 +37,7 @@
     <changelist>999999-SNAPSHOT</changelist>
 
     <!-- https://www.jenkins.io/doc/developer/plugin-development/choosing-jenkins-baseline/ -->
-    <jenkins.baseline>2.504</jenkins.baseline>
+    <jenkins.baseline>2.541</jenkins.baseline>
     <jenkins.version>${jenkins.baseline}.3</jenkins.version>
     <gitHubRepo>jenkinsci/${project.artifactId}-plugin</gitHubRepo>
 
@@ -51,7 +51,7 @@
         <!-- Pick up common dependencies for the selected LTS line: https://github.com/jenkinsci/bom#usage -->
         <groupId>io.jenkins.tools.bom</groupId>
         <artifactId>bom-${jenkins.baseline}.x</artifactId>
-        <version>5983.v443959746f1f</version>
+        <version>6421.v4a_efb_4b_3a_61d</version>
         <type>pom</type>
         <scope>import</scope>
       </dependency>

--- a/src/main/java/com/github/cyanbaz/jenkins/plugins/jsonparameter/JsonSource.java
+++ b/src/main/java/com/github/cyanbaz/jenkins/plugins/jsonparameter/JsonSource.java
@@ -6,7 +6,7 @@ package com.github.cyanbaz.jenkins.plugins.jsonparameter;
 
 import com.jayway.jsonpath.JsonPath;
 import hudson.ExtensionPoint;
-import hudson.model.AbstractDescribableImpl;
+import hudson.model.Describable;
 import hudson.util.ListBoxModel;
 import java.io.IOException;
 import java.io.Serial;
@@ -30,7 +30,7 @@ import java.util.List;
  *
  * @author Caner Yanbaz
  */
-public abstract class JsonSource extends AbstractDescribableImpl<JsonSource> implements ExtensionPoint, Serializable {
+public abstract class JsonSource implements ExtensionPoint, Serializable, Describable<JsonSource> {
 
     @Serial
     private static final long serialVersionUID = 1L;

--- a/src/main/java/com/github/cyanbaz/jenkins/plugins/jsonparameter/RemoteSource.java
+++ b/src/main/java/com/github/cyanbaz/jenkins/plugins/jsonparameter/RemoteSource.java
@@ -159,6 +159,7 @@ public class RemoteSource extends JsonSource {
         }
     }
 
+    @SuppressWarnings("resource")
     private String executeRequest(HttpRequest request) throws IOException, InterruptedException {
         HttpClient client = ProxyConfiguration.newHttpClient();
         HttpResponse<String> response = client.send(request, HttpResponse.BodyHandlers.ofString());


### PR DESCRIPTION
Updates the plugin baseline to Jenkins 2.541.3 and modernizes the CI/runtime configuration.

This keeps older Jenkins installations on the previous compatible plugin release, while newer Jenkins versions can use the updated release line.

### Testing done

Manually tested the changed behavior in Jenkins with:

- Freestyle jobs
- Pipeline jobs
- Remote JSON source
- Config-based JSON source
- `jsonParam`
- `jsonParamRef`

Verified that options are loaded correctly for all tested combinations.

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests that demonstrate the feature works or the issue is fixed